### PR TITLE
Use XDG spec paths for storing configuration

### DIFF
--- a/src/cmk.nim
+++ b/src/cmk.nim
@@ -9,10 +9,10 @@ type Category* = object
   cmd* : string
   des*  : string
     
-var file_path: string = getHomeDir() & ".comcek/cmd.yaml"
-    
+var file_path: string = getConfigDir() & "comcek/cmd.yaml"
+
 # echo file_path
-# /home/myuser/.comcek/cmd.yaml
+# $XDG_CONFIG_HOME/.comcek/cmd.yaml
 
 var cmd_file = newFileStream(file_path, fmRead)
 


### PR DESCRIPTION
Using the `ospaths` `getConfigDir` to conform to the XDG spec [1].

[1] https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

Signed-off-by: Christian Witts <cwitts@gmail.com>